### PR TITLE
Fix typos of `fuction` to `function`

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1930,7 +1930,7 @@ class MklPrimitiveFactory {
             !port::TestCPUFeature(port::CPUFeature::AVX2));
   }
 
-  /// Fuction to check whether primitive memory optimization is enabled
+  /// function to check whether primitive memory optimization is enabled
   static inline bool IsPrimitiveMemOptEnabled() {
     bool is_primitive_mem_opt_enabled = true;
     TF_CHECK_OK(ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE", true,
@@ -2107,7 +2107,7 @@ class MklReorderPrimitiveFactory : public MklPrimitiveFactory<T> {
   }
 };
 
-/// Fuction to find(or create) a reorder from memory pointed by
+/// function to find(or create) a reorder from memory pointed by
 /// from to memory pointed by to, it will created primitive or
 /// get primitive from pool if it is cached.
 /// Returns the primitive.

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1930,7 +1930,7 @@ class MklPrimitiveFactory {
             !port::TestCPUFeature(port::CPUFeature::AVX2));
   }
 
-  /// function to check whether primitive memory optimization is enabled
+  /// Function to check whether primitive memory optimization is enabled
   static inline bool IsPrimitiveMemOptEnabled() {
     bool is_primitive_mem_opt_enabled = true;
     TF_CHECK_OK(ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE", true,
@@ -2107,7 +2107,7 @@ class MklReorderPrimitiveFactory : public MklPrimitiveFactory<T> {
   }
 };
 
-/// function to find(or create) a reorder from memory pointed by
+/// Function to find(or create) a reorder from memory pointed by
 /// from to memory pointed by to, it will created primitive or
 /// get primitive from pool if it is cached.
 /// Returns the primitive.

--- a/tensorflow/lite/experimental/micro/riscv32_mcu/debug_log.cc
+++ b/tensorflow/lite/experimental/micro/riscv32_mcu/debug_log.cc
@@ -9,7 +9,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-// TODO(b/121324430): Add test for DebugLog fuctions
+// TODO(b/121324430): Add test for DebugLog functions
 // TODO(b/121275099): Remove dependency on debug_log once the platform supports
 // printf
 

--- a/tensorflow/lite/kernels/internal/quantization_util.cc
+++ b/tensorflow/lite/kernels/internal/quantization_util.cc
@@ -372,7 +372,7 @@ void FakeQuantizeArray(const float nudged_scale, const float nudged_min,
 
 bool CheckedLog2(const float x, int* log2_result) {
   // Using TfLiteRound instead of std::round and std::log instead of
-  // std::log2 to work around these fuctions being missing in a toolchain
+  // std::log2 to work around these functions being missing in a toolchain
   // used in some TensorFlow tests as of May 2018.
   const float x_log2 = std::log(x) * (1.0f / std::log(2.0f));
   const float x_log2_rounded = TfLiteRound(x_log2);

--- a/tensorflow/python/keras/distribute/distributed_training_utils.py
+++ b/tensorflow/python/keras/distribute/distributed_training_utils.py
@@ -936,7 +936,7 @@ def _make_execution_function_with_cloning(model, mode):
     distributed_model = get_distributed_model(model, mode)
   assert distributed_model
 
-  # Also create an execution fuction on that distributed model.
+  # Also create an execution function on that distributed model.
   if context.executing_eagerly():
     distributed_function = _make_eager_execution_function(model, mode)
   else:


### PR DESCRIPTION
I found some typos of `fuction` in several comments that they are probably meant to be written as `function`.

All such ones should be corrected though they have nothing to do with working codes.