### PR TITLE
Combined TF_RET_CHECK condition and initialised compile_time_const_ar…

### DIFF
--- a/tensorflow/compiler/tf2xla/const_analysis.cc
+++ b/tensorflow/compiler/tf2xla/const_analysis.cc
@@ -61,13 +61,15 @@ Status GetFunctionBodies(FunctionLibraryRuntime* flib_runtime,
 
 Status CondConstInputIndices(
     absl::Span<const FunctionBody* const> branch_bodies,
-    std::vector<int>* const_input_idxs, FunctionLibraryRuntime* flib_runtime) {
-  TF_RET_CHECK(!branch_bodies.empty());
+
   TF_RET_CHECK(branch_bodies[0] != nullptr);
+    std::vector<int>* const_input_idxs, FunctionLibraryRuntime* flib_runtime) {
+  TF_RET_CHECK(!branch_bodies.empty() && branch_bodies[0] != nullptr);
+
   int num_inputs = branch_bodies[0]->fdef.signature().input_arg_size();
   // Stores indices of the "branch function" inputs that are expected to be
   // compile time constants.
-  std::vector<bool> compile_time_const_arg_indices(num_inputs);
+  std::vector<bool> compile_time_const_arg_indices(num_inputs, false);
   for (auto fbody : branch_bodies) {
     TF_RET_CHECK(fbody != nullptr);
     TF_RETURN_IF_ERROR(BackwardsConstAnalysis(


### PR DESCRIPTION
…g_indices to avoid redundant initialisation

Combined the TF_RET_CHECK conditions using && for conciseness. Initialized compile_time_const_arg_indices with false values to avoid redundant initialization in the loop.